### PR TITLE
Module missing files

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
     "README.md",
     "LICENSE.txt",
     "transport.js",
-    "lib/transport-utils.js"
+    "lib/transport-utils.js",
+    "lib/http.js",
+    "lib/tcp.js"
   ],
   "devDependencies": {
     "async": "1.5.x",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seneca-transport",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Seneca transport",
   "main": "transport.js",
   "scripts": {


### PR DESCRIPTION
not adding `lib/http.js` & `lib/tcp.js` to files in package.json means that this two guys were missing from published module.