### PR TITLE
memory leak fix for tcp reconnect and typo fix for pushing tcp connections

### DIFF
--- a/lib/tcp.js
+++ b/lib/tcp.js
@@ -124,7 +124,7 @@ exports.client = function (options, transportUtil) {
         seneca.log.debug('client', type, 'connect', spec, topic, clientOptions)
         connection.clientOptions = clientOptions // unique per connection
         connections.push(connection)
-        established = true;
+        established = true
       })
       reconnect.on('reconnect', function () {
         seneca.log.debug('client', type, 'reconnect', spec, topic, clientOptions)

--- a/lib/tcp.js
+++ b/lib/tcp.js
@@ -96,7 +96,7 @@ exports.client = function (options, transportUtil) {
         // unique connections are by the options e.g. host:port
         // don't need to pipe everything again if it exists
         // established is for a race condition for `connect` event pushing
-        if (established) {
+        if (!established) {
           var existing = _.find(connections, { clientOptions: clientOptions })
 
           if (existing) {

--- a/lib/tcp.js
+++ b/lib/tcp.js
@@ -124,6 +124,7 @@ exports.client = function (options, transportUtil) {
         seneca.log.debug('client', type, 'connect', spec, topic, clientOptions)
         connection.clientOptions = clientOptions // unique per connection
         connections.push(connection)
+        established = true;
       })
       reconnect.on('reconnect', function () {
         seneca.log.debug('client', type, 'reconnect', spec, topic, clientOptions)

--- a/lib/tcp.js
+++ b/lib/tcp.js
@@ -8,6 +8,7 @@ var Net = require('net')
 var Stream = require('stream')
 var Ndjson = require('ndjson')
 var Reconnect = require('reconnect-core')
+var _ = require('lodash')
 
 // Declare internals
 var internals = {}
@@ -89,9 +90,20 @@ exports.client = function (options, transportUtil) {
     var send = function (spec, topic, send_done) {
       seneca.log.debug('client', type, 'send-init', spec, topic, clientOptions)
 
-      var connections = []
+      var connections = [], established = false
 
       var reconnect = internals.reconnect(function (stream) {
+        // unique connections are by the options e.g. host:port
+        // don't need to pipe everything again if it exists
+        // established is for a race condition for `connect` event pushing
+        if (established) {
+          var existing = _.find(connections, { clientOptions: clientOptions })
+
+          if (existing) {
+            return
+          }
+        }
+
         var msger = internals.clientMessager(seneca, clientOptions, transportUtil)
         var parser = Ndjson.parse()
         var stringifier = Ndjson.stringify()
@@ -110,7 +122,8 @@ exports.client = function (options, transportUtil) {
 
       reconnect.on('connect', function (connection) {
         seneca.log.debug('client', type, 'connect', spec, topic, clientOptions)
-        connections.push(connections)
+        connection.clientOptions = clientOptions // unique per connection
+        connections.push(connection)
       })
       reconnect.on('reconnect', function () {
         seneca.log.debug('client', type, 'reconnect', spec, topic, clientOptions)

--- a/lib/tcp.js
+++ b/lib/tcp.js
@@ -90,7 +90,8 @@ exports.client = function (options, transportUtil) {
     var send = function (spec, topic, send_done) {
       seneca.log.debug('client', type, 'send-init', spec, topic, clientOptions)
 
-      var connections = [], established = false
+      var connections = []
+      var established = false
 
       var reconnect = internals.reconnect(function (stream) {
         // unique connections are by the options e.g. host:port

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seneca-transport",
-  "version": "0.8.3",
+  "version": "0.8.2",
   "description": "Seneca transport",
   "main": "transport.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seneca-transport",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Seneca transport",
   "main": "transport.js",
   "scripts": {


### PR DESCRIPTION
Found the memory leak issue by trying out seneca for the first time :)

My setup was as follows:

Seneca service listening on localhost:9090
API that had a client connected to localhost:9090

If the seneca service restarted about 8 times without the api restarting, you would get memory leak warnings from the event emitter on the API from the client.

This fix skips the initial setup of the socket connection if it's already been established.