### PR TITLE
use Jsonic over JSON.parse

### DIFF
--- a/lib/transport-utils.js
+++ b/lib/transport-utils.js
@@ -501,7 +501,7 @@ internals.Utils.prototype.parseJSON = function (seneca, note, str) {
   }
 
   try {
-    return JSON.parse(str)
+    return Jsonic(str)
   }
   catch (e) {
     seneca.log.warn('json-parse', note, str.replace(/[\r\n\t]+/g, ''), e.message)


### PR DESCRIPTION
Turns out in #63 I had "bad" json being passed sent to my server. Instead of trying to parse the input with JSON.parse, maybe we should use jsonic to parse it?