### PR TITLE
support custom statusCode to response

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -221,14 +221,14 @@ internals.trackHeaders = function (listenOptions, seneca, transportUtil, req, re
 
 internals.sendResponse = function (seneca, transportUtil, res, out, data) {
   var outJson = 'null'
-  var isError = false
   var httpcode = 200
 
   if (out && out.res) {
+    httpcode = out.res.statusCode || httpcode
     outJson = transportUtil.stringifyJSON(seneca, 'listen-web', out.res)
   }
   else if (out && out.error) {
-    isError = true
+    httpcode = out.error.statusCode || 500
     outJson = transportUtil.stringifyJSON(seneca, 'listen-web', out.error)
   }
 
@@ -249,10 +249,6 @@ internals.sendResponse = function (seneca, transportUtil, res, out, data) {
     out && out.item ? out.time.listen_recv : '0'
   headers['seneca-time-listen-sent'] =
     out && out.item ? out.time.listen_sent : '0'
-
-  if (isError) {
-    httpcode = 500
-  }
 
   res.writeHead(httpcode, headers)
   res.end(outJson)


### PR DESCRIPTION
I'm wondering if this is a possible way to pass a custom http status code from an action through to the HTTP response. Sometimes we want to return a 400 (or other) HTTP status code in case of an error, and currently every error ends up being a 500.

I also moved the isError branch since it looked more concise in the top if-else