### PR TITLE
Tcp crash fix

### DIFF
--- a/lib/tcp.js
+++ b/lib/tcp.js
@@ -26,6 +26,11 @@ exports.listen = function (options, transportUtil) {
 
       var parser = Ndjson.parse()
       var stringifier = Ndjson.stringify()
+      //tcp-crash-fix-by-peterli888
+      parser.on('error', function (error) {
+          connection.end();
+      });
+      //tcp-crash-fix-by-peterli888
       parser.on('data', function (data) {
         if (Util.isError(data)) {
           var out = transportUtil.prepareResponse(seneca, {})

--- a/lib/tcp.js
+++ b/lib/tcp.js
@@ -26,11 +26,11 @@ exports.listen = function (options, transportUtil) {
 
       var parser = Ndjson.parse()
       var stringifier = Ndjson.stringify()
-      //tcp-crash-fix-by-peterli888
+      //tcp-crash-fixed-by-peterli888
       parser.on('error', function (error) {
           connection.end();
       });
-      //tcp-crash-fix-by-peterli888
+      //tcp-crash-fixed-by-peterli888
       parser.on('data', function (data) {
         if (Util.isError(data)) {
           var out = transportUtil.prepareResponse(seneca, {})


### PR DESCRIPTION
seneca.listen({type:'tcp',port:3000});
curl "http://localhost:3000" will crash the server

howto-fix:
file:seneca-transport // tcp.js
before: "parser.on('data', function (data) "
add:
parser.on('error', function (error) {
     connection.end();
});