### PR TITLE
Add the ability to add headers to web client requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -696,7 +696,7 @@ function hook_client_redis( args, clientdone ) {
       // this will be done for you
     })
   }
-}  
+}
 ```
 
 To implement the server, use the template:
@@ -820,6 +820,7 @@ The transport-level options vary by transport. Here are the default ones for HTT
    * _path_: URL path to submit messages; default: '/act'
    * _protocol_: HTTP protocol; default 'http'
    * _timeout_: timeout in milliseconds; default: 5555
+   * _headers_: extra headers to include in requests the transport makes; default {}
 
 And for TCP:
 

--- a/lib/http.js
+++ b/lib/http.js
@@ -75,6 +75,15 @@ exports.client = function (options, transportUtil) {
   return function (msg, callback) {
     var seneca = this
     var clientOptions = seneca.util.deepextend(options[msg.type], msg)
+    var defaultHeaders = null
+
+    // these are seneca internal, users are not allowed to change them
+    if (options[msg.type].headers) {
+      defaultHeaders = _.omit(options[msg.type].headers,
+        ['Accept', 'Content-Type', 'Content-Length', 'Cache-Control', 'seneca-id',
+          'seneca-kind', 'seneca-origin', 'seneca-track', 'seneca-time-client-sent',
+          'seneca-accept', 'seneca-time-listen-recv', 'seneca-time-listen-sent'])
+    }
 
     var send = function (spec, topic, send_done) {
       var host = transportUtil.resolveDynamicValue(clientOptions.host, clientOptions)
@@ -97,6 +106,10 @@ exports.client = function (options, transportUtil) {
           'seneca-origin': seneca.id,
           'seneca-track': transportUtil.stringifyJSON(seneca, 'send-track', data.track || []),
           'seneca-time-client-sent': data.time.client_sent
+        }
+
+        if (defaultHeaders) {
+          _.assign(headers, defaultHeaders)
         }
 
         var requestOptions = {

--- a/test/transport.test.js
+++ b/test/transport.test.js
@@ -240,6 +240,35 @@ describe('transport', function() {
     )
   })
 
+  it('web-add-headers', function( fin ) {
+    Seneca({log:'silent',errhandler:fin,default_plugins:no_t})
+      .use('../transport.js')
+      .add( 'c:1', function(args,done){done(null,{s:'1-'+args.d})} )
+      .listen({type:'web',port:20205})
+      .ready( function() {
+        var tag
+
+        Seneca({tag:tag, log:'silent',default_plugins:no_t,debug:{short_logs:true}})
+          .use(Transport, { web: {headers: {'client-id': 'test-client' }}})
+          .client({ type: 'web', port: 20205 })
+          .ready( function() {
+
+            this.act('c:1,d:A',function(err,out){
+              if(err) return fin(err);
+
+              assert.equal( '{"s":"1-A"}', JSON.stringify(out) )
+
+              this.act('c:1,d:AA',function(err,out){
+                if(err) return fin(err);
+
+                assert.equal( '{"s":"1-AA"}', JSON.stringify(out) )
+
+                this.close(fin)
+              })
+            })
+          })
+      })
+  })
 
   it('error-passing-http', function (fin) {
     Seneca({ log: 'silent', default_plugins: no_t })


### PR DESCRIPTION
Add an option named headers that users can use to add headers to client requests
the web transport makes. You'd use this by adding the object:

```javascript
{
  web: {
    headers: {
      'client-id': 'test-client'
    }
  }
}
```

to the use statement for the transport. This adds the header 'client-id' with
the value 'test-client' to requests that the web client makes to other
seneca services.

Closes #71 