### PR TITLE
Fix host handling to support Windows platforms

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -90,7 +90,8 @@ exports.client = function (options, transportUtil) {
       var port = transportUtil.resolveDynamicValue(clientOptions.port, clientOptions)
       var path = transportUtil.resolveDynamicValue(clientOptions.path, clientOptions)
 
-      host = !options[msg.type].host && host === '0.0.0.0' ? '127.0.0.1' : host
+      // never use a 0.0.0.0 as targeted host, because Windows can't handle it
+      host = host === '0.0.0.0' ? '127.0.0.1' : host
 
       var url = 'http://' + host + ':' + port + path
       seneca.log.debug('client', 'web', 'send', spec, topic, clientOptions, url)

--- a/lib/tcp.js
+++ b/lib/tcp.js
@@ -104,6 +104,10 @@ exports.client = function (options, transportUtil) {
   return function (args, callback) {
     var seneca = this
     var type = args.type
+    if (args.host) {
+      // under Windows host, 0.0.0.0 host will always fail
+      args.host = args.host === '0.0.0.0' ? '127.0.0.1' : args.host
+    }
     var clientOptions = seneca.util.deepextend(options[args.type], args)
     clientOptions.host = !args.host && clientOptions.host === '0.0.0.0' ? '127.0.0.1' : clientOptions.host
 

--- a/test/tcp.test.js
+++ b/test/tcp.test.js
@@ -51,7 +51,7 @@ describe('tcp', function () {
       })
     })
 
-    it('can listen on unix path', function (done) {
+    it('can listen on unix path', {skip: /win/.test(process.platform)}, function (done) {
       var sock = '/tmp/seneca.sock'
       // Remove existing sock file
       if (Fs.existsSync(sock)) {


### PR DESCRIPTION
I'm running Windows, and I add problems with [seneca-mesh](https://github.com/rjrodger/seneca-mesh) discovery when all microservices are on the same host.

It turns out that seneca-transport  was in cause, *only when host are not specified*.
This small PR allows to run all test under Windows, except the "tcp listen() can listen on unix path" which was disabled when platform is win*