### PR TITLE
Ensure http errors send a response

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -123,7 +123,7 @@ exports.client = function (options, transportUtil) {
         }
 
         Wreck.post(url, requestOptions, function (err, res, payload) {
-          var data = {
+          var response = {
             kind: 'res',
             res: payload && _.isObject(payload) ? payload : null,
             error: err,
@@ -131,21 +131,25 @@ exports.client = function (options, transportUtil) {
           }
 
           if (res) {
-            data.id = res.headers['seneca-id']
-            data.origin = res.headers['seneca-origin']
-            data.accept = res.headers['seneca-accept']
-            data.time = {
+            response.id = res.headers['seneca-id']
+            response.origin = res.headers['seneca-origin']
+            response.accept = res.headers['seneca-accept']
+            response.time = {
               client_sent: res.headers['seneca-time-client-sent'],
               listen_recv: res.headers['seneca-time-listen-recv'],
               listen_sent: res.headers['seneca-time-listen-sent']
             }
 
             if (res.statusCode !== 200) {
-              data.error = payload
+              response.error = payload
             }
           }
+          else {
+            response.id = data.id
+            response.origin = seneca.id
+          }
 
-          transportUtil.handle_response(seneca, data, clientOptions)
+          transportUtil.handle_response(seneca, response, clientOptions)
         })
       }
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "Geoffrey Clements (https://github.com/baldmountain)",
     "Rumkin (https://github.com/rumkin)",
     "Boris Jonica (https://github.com/bjonica)",
-    "Damien Simonin Feugas (https://github.com/feugy)"
+    "Damien Simonin Feugas (https://github.com/feugy)",
+    "Tyler Waters (https://github.com/tswaters)"
   ],
   "dependencies": {
     "eraro": "0.4.1",
@@ -68,7 +69,8 @@
     "pre-commit": "1.1.x",
     "seneca": "plugin",
     "seneca-entity": "1.3.x",
-    "seneca-transport-test": "0.2.0"
+    "seneca-transport-test": "0.2.0",
+    "sinon": "^1.17.6"
   },
   "files": [
     "transport.js",


### PR DESCRIPTION
Fixes #132

The test is a little bit messy due to complicated nature of making wreck (and by extension http.request) throw an http error.  It passes though -- and without the change in lib/http.js it will timeout, so it does highlight the problem.
