### PR TITLE
Fix #97: Pins not working in TCP / HTTP listen options

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -25,6 +25,7 @@ exports.listen = function (options, transportUtil) {
     var listener
     var listenAttempts = 0
     var listen_details = _.clone(msg)
+    var pins = transportUtil.resolve_pins(msg)
 
     server.on('request', function (req, res) {
       internals.timeout(listenOptions, req, res)
@@ -34,7 +35,7 @@ exports.listen = function (options, transportUtil) {
           return res.end()
         }
 
-        internals.trackHeaders(listenOptions, seneca, transportUtil, req, res)
+        internals.trackHeaders(listenOptions, seneca, transportUtil, req, res, pins)
       })
     })
 
@@ -200,7 +201,7 @@ internals.setBody = function (seneca, transportUtil, req, res, next) {
   })
 }
 
-internals.trackHeaders = function (listenOptions, seneca, transportUtil, req, res) {
+internals.trackHeaders = function (listenOptions, seneca, transportUtil, req, res, pins) {
   if (req.url.indexOf(listenOptions.path) !== 0) {
     return
   }
@@ -229,6 +230,17 @@ internals.trackHeaders = function (listenOptions, seneca, transportUtil, req, re
         client_sent: Date.now()
       },
       act: req.body
+    }
+  }
+
+  // Issue: #97
+  if (pins) {
+    // any topic is not pinned, verifying the calling one is pinned
+    var argspatrun = transportUtil.make_argspatrun(pins)
+    if (!argspatrun.find(req.body)) {
+      data.error = transportUtil.error('not_pinned', { act: req.body })
+      data.error.statusCode = 404
+      return internals.sendResponse(seneca, transportUtil, res, data, {})
     }
   }
 

--- a/lib/tcp.js
+++ b/lib/tcp.js
@@ -20,6 +20,8 @@ exports.listen = function (options, transportUtil) {
     var connections = []
     var listenAttempts = 0
 
+    var pins = transportUtil.resolve_pins(args)
+
     var listener = Net.createServer(function (connection) {
       seneca.log.debug('listen', 'connection', listenOptions,
                        'remote', connection.remoteAddress, connection.remotePort)
@@ -40,7 +42,20 @@ exports.listen = function (options, transportUtil) {
           return
         }
 
-        transportUtil.handle_request(seneca, data, options, function (out) {
+        // Issue: #97
+        if (pins) {
+          // any topic is not pinned, verifying the calling one is pinned
+          var argspatrun = transportUtil.make_argspatrun(pins)
+          if (!argspatrun.find(data.act)) {
+            out = transportUtil.prepareResponse(seneca, data)
+            out.error = transportUtil.error('not_pinned', data)
+
+            stringifier.write(out)
+            return
+          }
+        }
+
+        transportUtil.handle_request(seneca, data, listenOptions, function (out) {
           if (out === null || !out.sync) {
             return
           }

--- a/lib/transport-utils.js
+++ b/lib/transport-utils.js
@@ -24,7 +24,8 @@ var internals = {
       'message_loop': 'Inbound message rejected as looping back to this server.',
       'data_error': 'Inbound message included an error description.',
       'invalid_json': 'Invalid JSON: <%=input%>.',
-      'unexcepted_async_error': 'Unexcepted error response to asynchronous message.'
+      'unexcepted_async_error': 'Unexcepted error response to asynchronous message.',
+      'not_pinned': 'Inbound message <%=act%> rejected as not pinned'
     },
     override: true
   })

--- a/test/misc.test.js
+++ b/test/misc.test.js
@@ -348,4 +348,58 @@ describe('Miscellaneous', function () {
         }
       })
   })
+
+  it('listen-tcp-pin (#97)', function (fin) {
+    CreateInstance()
+      .add('foo:1', function (args, done) {
+        done(null, {FOO: 1})
+      })
+      .add('bar:1', function (args, done) {
+        done(null, {BAR: 1})
+      })
+      .listen({type: 'tcp', port: '9999', pin: 'foo:*'})
+
+      .ready(function () {
+        var siClient = CreateInstance()
+          .client({type: 'tcp', port: '9999'})
+
+        siClient.act('foo:1', function (err, out) {
+          Assert.equal(err, null)
+          Assert.equal(1, out.FOO)
+
+          siClient.act('bar:1', function (err, out) {
+            Assert.equal(err.code, 'not_pinned')
+            if (err) return fin()
+            fin(new Error('Not pinned service called'))
+          })
+        })
+      })
+  })
+  it('listen-http-pin (#97)', function (fin) {
+    CreateInstance()
+      .add('foo:1', function (args, done) {
+        done(null, {FOO: 1})
+      })
+      .add('bar:1', function (args, done) {
+        done(null, {BAR: 1})
+      })
+      .listen({type: 'http', port: '9998', pin: 'foo:*'})
+
+      .ready(function () {
+        var siClient = CreateInstance()
+          .client({type: 'http', port: '9998'})
+
+        siClient.act('foo:1', function (err, out) {
+          Assert.equal(err, null)
+          Assert.equal(1, out.FOO)
+
+          siClient.act('bar:1', function (err, out) {
+            Assert.equal(err.statusCode, 404)
+            Assert.equal(err.code, 'not_pinned')
+            if (err) return fin()
+            fin(new Error('Not pinned service called'))
+          })
+        })
+      })
+  })
 })


### PR DESCRIPTION
I investigated and have a fix proposal concerning the issue #97.

I added two tests in misc.test.js concerning the listen service pin options. 
I added error message 'not_pinned' in transport-utils.js to differentiate the error due to a call to a service that has not been 'published' by the server. 

I upgraded tcp and http accordingly to:
- retrieve the pins topics in listen call
- check the topic access on remote call by using patrun
- in TCP the eraro is produced and returned if called topic does not match the exposed topics (through pins)
- In HTTP, the eraro is produced and encapsulated in an HTTP 404 response!

I hope it helps,
Regards,
Jérôme
