### PR TITLE
Fix #140 and #139 by adding an Inward/Outward mechanism for remote call

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -253,13 +253,13 @@ internals.sendResponse = function (seneca, transportUtil, res, out, data) {
   var outJson = 'null'
   var httpcode = 200
 
-  if (out && out.res) {
-    httpcode = out.res.statusCode || httpcode
-    outJson = transportUtil.stringifyJSON(seneca, 'listen-web', out.res)
-  }
-  else if (out && out.error) {
+  if (out && out.error) {
     httpcode = out.error.statusCode || 500
     outJson = transportUtil.stringifyJSON(seneca, 'listen-web', out.error)
+  }
+  else if (out && out.res) {
+    httpcode = out.res.statusCode || httpcode
+    outJson = transportUtil.stringifyJSON(seneca, 'listen-web', out.res)
   }
 
   var headers = {

--- a/lib/http.js
+++ b/lib/http.js
@@ -25,6 +25,7 @@ exports.listen = function (options, transportUtil) {
     var listener
     var listenAttempts = 0
     var listen_details = _.clone(msg)
+    var pins = transportUtil.resolve_pins(msg)
 
     server.on('request', function (req, res) {
       internals.timeout(listenOptions, req, res)
@@ -34,7 +35,7 @@ exports.listen = function (options, transportUtil) {
           return res.end()
         }
 
-        internals.trackHeaders(listenOptions, seneca, transportUtil, req, res)
+        internals.trackHeaders(listenOptions, seneca, transportUtil, req, res, pins)
       })
     })
 
@@ -200,7 +201,7 @@ internals.setBody = function (seneca, transportUtil, req, res, next) {
   })
 }
 
-internals.trackHeaders = function (listenOptions, seneca, transportUtil, req, res) {
+internals.trackHeaders = function (listenOptions, seneca, transportUtil, req, res, pins) {
   if (req.url.indexOf(listenOptions.path) !== 0) {
     return
   }
@@ -229,6 +230,17 @@ internals.trackHeaders = function (listenOptions, seneca, transportUtil, req, re
         client_sent: Date.now()
       },
       act: req.body
+    }
+  }
+
+  // Issue: #97
+  if (pins) {
+    // any topic is not pinned, verifying the calling one is pinned
+    var argspatrun = transportUtil.make_argspatrun(pins)
+    if (!argspatrun.find(req.body)) {
+      data.error = transportUtil.error('not_pinned', { act: req.body })
+      data.error.statusCode = 404
+      return internals.sendResponse(seneca, transportUtil, res, data, {})
     }
   }
 

--- a/lib/tcp.js
+++ b/lib/tcp.js
@@ -20,6 +20,8 @@ exports.listen = function (options, transportUtil) {
     var connections = []
     var listenAttempts = 0
 
+    var pins = transportUtil.resolve_pins(args)
+
     var listener = Net.createServer(function (connection) {
       seneca.log.debug('listen', 'connection', listenOptions,
                        'remote', connection.remoteAddress, connection.remotePort)
@@ -40,7 +42,20 @@ exports.listen = function (options, transportUtil) {
           return
         }
 
-        transportUtil.handle_request(seneca, data, options, function (out) {
+        // Issue: #97
+        if (pins) {
+          // any topic is not pinned, verifying the calling one is pinned
+          var argspatrun = transportUtil.make_argspatrun(pins)
+          if (!argspatrun.find(data.act)) {
+            out = transportUtil.prepareResponse(seneca, data)
+            out.error = transportUtil.error('not_pinned', data)
+
+            stringifier.write(out)
+            return
+          }
+        }
+
+        transportUtil.handle_request(seneca, data, listenOptions, function (out) {
           if (out === null || !out.sync) {
             return
           }

--- a/lib/transport-utils.js
+++ b/lib/transport-utils.js
@@ -507,18 +507,21 @@ internals.Utils.prototype.handle_entity = function (seneca, raw) {
   // in a seneca context that does not support entity.
   // Don't try to "make" them as it is not supported and lead to:
   // TypeError: seneca.make$ is not a function
-  if (seneca.make$) {
-    if (raw.entity$) {
-      return seneca.make$(raw)
-    }
-
-    _.each(raw, function (value, key) {
-      if (_.isObject(value) && value.entity$) {
-        raw[key] = seneca.make$(value)
-      }
-    })
+  function make (entity) {
+    if (seneca.make$) return seneca.make$(entity)
+    else seneca.log.warn('[', entity, '] cannot be used as entity. seneca-entity plugin is missing.')
+    return entity
   }
 
+  if (raw.entity$) {
+    return make(raw)
+  }
+
+  _.each(raw, function (value, key) {
+    if (_.isObject(value) && value.entity$) {
+      raw[key] = make(value)
+    }
+  })
   return raw
 }
 

--- a/lib/transport-utils.js
+++ b/lib/transport-utils.js
@@ -24,7 +24,8 @@ var internals = {
       'message_loop': 'Inbound message rejected as looping back to this server.',
       'data_error': 'Inbound message included an error description.',
       'invalid_json': 'Invalid JSON: <%=input%>.',
-      'unexcepted_async_error': 'Unexcepted error response to asynchronous message.'
+      'unexcepted_async_error': 'Unexcepted error response to asynchronous message.',
+      'not_pinned': 'Inbound message <%=act%> rejected as not pinned'
     },
     override: true
   })

--- a/lib/transport-utils.js
+++ b/lib/transport-utils.js
@@ -99,7 +99,6 @@ internals.Utils.prototype.handle_response = function (seneca, data, client_optio
     return false
   }
 
-
   var actinfo = {
     id: data.id,
     accept: data.accept,
@@ -234,14 +233,34 @@ internals.Utils.prototype.handle_request = function (seneca, data, listen_option
 
   input.id$ = data.id
 
-  this.requestAct(seneca, input, output, respond)
+  this.requestAct(seneca, input, output, respond, listen_options.inward, listen_options.outward)
 }
 
-internals.Utils.prototype.requestAct = function (seneca, input, output, respond) {
+internals.Utils.prototype.requestAct = function (seneca, input, output, respond, inward, outward) {
   var self = this
 
   try {
+    if (inward) {
+      inward({ seneca }, { msg: input })
+    }
     seneca.act(input, function (err, out) {
+      if (outward) {
+        try {
+          var outward_data = {
+            err: err,
+            msg: input,
+            res: out
+          }
+          outward({ seneca }, outward_data)
+          err = outward_data.err
+          out = outward_data.res
+        }
+        catch (e) {
+          // outward failed, keep a trace of the original err if there was one
+          e.act_error = err
+          err = e
+        }
+      }
       self.update_output(input, output, err, out)
       respond(output)
     })

--- a/lib/transport-utils.js
+++ b/lib/transport-utils.js
@@ -484,15 +484,21 @@ internals.Utils.prototype.handle_entity = function (seneca, raw) {
 
   raw = _.isObject(raw) ? raw : {}
 
-  if (raw.entity$) {
-    return seneca.make$(raw)
-  }
-
-  _.each(raw, function (value, key) {
-    if (_.isObject(value) && value.entity$) {
-      raw[key] = seneca.make$(value)
+  // FIX #135 - entity is now optional in seneca, entity sent remotely may arrive
+  // in a seneca context that does not support entity.
+  // Don't try to "make" them as it is not supported and lead to:
+  // TypeError: seneca.make$ is not a function
+  if (seneca.make$) {
+    if (raw.entity$) {
+      return seneca.make$(raw)
     }
-  })
+
+    _.each(raw, function (value, key) {
+      if (_.isObject(value) && value.entity$) {
+        raw[key] = seneca.make$(value)
+      }
+    })
+  }
 
   return raw
 }

--- a/test/misc.test.js
+++ b/test/misc.test.js
@@ -44,7 +44,6 @@ describe('Miscellaneous', function () {
         counters.own++
       }
 
-
       var a = CreateInstance({
         log: {map: [
           {level: 'debug', regex: /\{a:1\}/, handler: log_a},
@@ -65,7 +64,6 @@ describe('Miscellaneous', function () {
             .add('b:1', counter_b)
             .listen({type: type, port: 40406})
             .client({type: type, port: 40405})
-
 
       a.ready(function () {
         b.ready(function () {
@@ -192,7 +190,6 @@ describe('Miscellaneous', function () {
             .add('c:1', counter_c)
             .listen({type: type, port: 40407})
             .client({type: type, port: 40405})
-
 
       a.ready(function () {
         b.ready(function () {
@@ -375,6 +372,7 @@ describe('Miscellaneous', function () {
         })
       })
   })
+
   it('listen-http-pin (#97)', function (fin) {
     CreateInstance()
       .add('foo:1', function (args, done) {

--- a/test/misc.test.js
+++ b/test/misc.test.js
@@ -348,4 +348,58 @@ describe('Miscellaneous', function () {
         }
       })
   })
+
+  it('listen-tcp-pin (#97)', function (fin) {
+    CreateInstance()
+      .add('foo:1', function (args, done) {
+        done(null, {FOO: 1})
+      })
+      .add('bar:1', function (args, done) {
+        done(null, {BAR: 1})
+      })
+      .listen({type: 'tcp', port: '9999', pin: 'foo:*'})
+
+      .ready(function () {
+        var siClient = CreateInstance()
+          .client({type: 'tcp', port: '9999'})
+
+        siClient.act('foo:1', function (err, out) {
+          Assert.equal(err, null)
+          Assert.equal(1, out.FOO)
+
+          siClient.act('bar:1', function (err, out) {
+            Assert.equal(err.code, 'not_pinned')
+            if (err) return fin()
+            fin(new Error('Not pinned service called'))
+          })
+        })
+      })
+  })
+  it('listen-http-pin (#97)', function (fin) {
+    CreateInstance()
+      .add('foo:1', function (args, done) {
+        done(null, {FOO: 1})
+      })
+      .add('bar:1', function (args, done) {
+        done(null, {BAR: 1})
+      })
+      .listen({type: 'http', port: '9998', pin: 'foo:*'})
+
+      .ready(function () {
+        var siClient = CreateInstance()
+          .client({type: 'http', port: '9998'})
+
+        siClient.act('foo:1', function (err, out) {
+          Assert.equal(err, null)
+          Assert.equal(1, out.FOO)
+
+          siClient.act('bar:1', function (err, out) {
+            Assert.equal(err.statusCode, 404)
+            Assert.equal(err.code, 'not_pinned')
+            if (err) return fin()
+            fin(new Error('Not pinned service called'))
+          })
+        })
+      })
+  })
 })

--- a/test/tcp.test.js
+++ b/test/tcp.test.js
@@ -214,105 +214,105 @@ describe('Specific tcp', function () {
 
       setTimeout(finish, 2000)
     })
+  })
 
-    it('apply inward/outward listen options on TCP remote act call', function (fin) {
-      CreateInstance()
-        .add('foo:1', function (args, done) {
-          done(null, { BAR: args.bar })
-        })
-        .listen({type: 'tcp', port: '19997',
-          inward: (context, data) => {
-            data.msg.bar += 1
-            data.msg.inward = 'INPUT UPGRADED'
-          },
-          outward: (context, data) => {
-            data.res.BAR += 10
-            data.res.inward = data.msg.inward
-            data.res.outward = 'OUTPUT UPGRADED'
-          }
-        })
-        .ready(function () {
-          var siClient = CreateInstance()
-            .client({type: 'tcp', port: '19997'})
+  it('apply inward/outward listen options on TCP remote act call', function (fin) {
+    CreateInstance()
+      .add('foo:1', function (args, done) {
+        done(null, { BAR: args.bar })
+      })
+      .listen({type: 'tcp', port: '19997',
+        inward: (context, data) => {
+          data.msg.bar += 1
+          data.msg.inward = 'INPUT UPGRADED'
+        },
+        outward: (context, data) => {
+          data.res.BAR += 10
+          data.res.inward = data.msg.inward
+          data.res.outward = 'OUTPUT UPGRADED'
+        }
+      })
+      .ready(function () {
+        var siClient = CreateInstance()
+          .client({type: 'tcp', port: '19997'})
 
-          siClient.act('foo:1,bar:2', function (err, out) {
-            if (err) return fin(err)
-            Assert.equal(out.BAR, 13)
-            Assert.equal(out.inward, 'INPUT UPGRADED')
-            Assert.equal(out.outward, 'OUTPUT UPGRADED')
-            fin()
-          })
+        siClient.act('foo:1,bar:2', function (err, out) {
+          if (err) return fin(err)
+          Assert.equal(out.BAR, 13)
+          Assert.equal(out.inward, 'INPUT UPGRADED')
+          Assert.equal(out.outward, 'OUTPUT UPGRADED')
+          fin()
         })
-    })
+      })
+  })
 
-    it('reject TCP remote act call in inward listen option', function (fin) {
-      CreateInstance()
-        .add('foo:1', function (args, done) {
-          done(null, { BAR: args.bar })
-        })
-        .listen({type: 'tcp', port: '19996',
-          inward: (context, data) => {
-            var e = new Error('TCP inward rejected!')
-            e.error_code = 'inward_rejected'
-            throw e
-          }
-        })
-        .ready(function () {
-          var siClient = CreateInstance()
-            .client({type: 'tcp', port: '19996'})
+  it('reject TCP remote act call in inward listen option', function (fin) {
+    CreateInstance()
+      .add('foo:1', function (args, done) {
+        done(null, { BAR: args.bar })
+      })
+      .listen({type: 'tcp', port: '19996',
+        inward: (context, data) => {
+          var e = new Error('TCP inward rejected!')
+          e.error_code = 'inward_rejected'
+          throw e
+        }
+      })
+      .ready(function () {
+        var siClient = CreateInstance()
+          .client({type: 'tcp', port: '19996'})
 
-          siClient.act('foo:1,bar:2', function (err, out) {
-            Assert.equal(err.error_code, 'inward_rejected')
-            if (err) return fin()
-            fin(new Error('Inward does not reject remote call'))
-          })
+        siClient.act('foo:1,bar:2', function (err, out) {
+          Assert.equal(err.error_code, 'inward_rejected')
+          if (err) return fin()
+          fin(new Error('Inward does not reject remote call'))
         })
-    })
+      })
+  })
 
-    it('reject TCP remote act call in outward listen option', function (fin) {
-      CreateInstance()
-        .add('foo:1', function (args, done) {
-          done(null, { BAR: args.bar })
-        })
-        .listen({type: 'tcp', port: '19995',
-          outward: (context, data) => {
-            var e = new Error('TCP outward rejected!')
-            e.error_code = 'outward_rejected'
-            throw e
-          }
-        })
-        .ready(function () {
-          var siClient = CreateInstance()
-            .client({type: 'tcp', port: '19995'})
+  it('reject TCP remote act call in outward listen option', function (fin) {
+    CreateInstance()
+      .add('foo:1', function (args, done) {
+        done(null, { BAR: args.bar })
+      })
+      .listen({type: 'tcp', port: '19995',
+        outward: (context, data) => {
+          var e = new Error('TCP outward rejected!')
+          e.error_code = 'outward_rejected'
+          throw e
+        }
+      })
+      .ready(function () {
+        var siClient = CreateInstance()
+          .client({type: 'tcp', port: '19995'})
 
-          siClient.act('foo:1,bar:2', function (err, out) {
-            Assert.equal(err.error_code, 'outward_rejected')
-            if (err) return fin()
-            fin(new Error('Outward does not reject remote call'))
-          })
+        siClient.act('foo:1,bar:2', function (err, out) {
+          Assert.equal(err.error_code, 'outward_rejected')
+          if (err) return fin()
+          fin(new Error('Outward does not reject remote call'))
         })
-    })
+      })
+  })
 
-    it('catch TCP remote act call error in outward listen option', function (fin) {
-      CreateInstance()
-        .add('foo:1', function (args, done) {
-          done(new Error('Catchable failure'), {BAR: args.bar})
-        })
-        .listen({type: 'tcp', port: '19994',
-          outward: (context, data) => {
-            delete data.err
-          }
-        })
-        .ready(function () {
-          var siClient = CreateInstance()
-            .client({type: 'tcp', port: '19994'})
+  it('catch TCP remote act call error in outward listen option', function (fin) {
+    CreateInstance()
+      .add('foo:1', function (args, done) {
+        done(new Error('Catchable failure'), {BAR: args.bar})
+      })
+      .listen({type: 'tcp', port: '19994',
+        outward: (context, data) => {
+          delete data.err
+        }
+      })
+      .ready(function () {
+        var siClient = CreateInstance()
+          .client({type: 'tcp', port: '19994'})
 
-          siClient.act('foo:1,bar:2', function (err, out) {
-            if (err) return fin(err)
-            Assert.equal(out.BAR, 2)
-            fin()
-          })
+        siClient.act('foo:1,bar:2', function (err, out) {
+          if (err) return fin(err)
+          Assert.equal(out.BAR, 2)
+          fin()
         })
-    })
+      })
   })
 })


### PR DESCRIPTION
#140 : The priority between error / result is now the same between TCP / HTTP. If an error and a message is returned, the error is now considered (in both TCP/HTTP) as more important and the act call fail.

#139 : An implementation for the server side is proposed. It allows to define an inward/outward hook in listen options. Those hooks are automatically invoked when receiving a remote act call. 
* Inward implementations can alter the incoming message, or even reject it
* Outward implementations can alter the outgoing result, or even consume an error and produce a default response 

Examples:
* Inward mechanism can be used to improve security checks, by extracting the user token from the request, ensure user is known and logged in
* Outward mechanism can be used to clean up response before they are sent, like removing all $ properties in case of seneca-entity usage on server and not on client