### PR TITLE
fix(tcp): fix duplication bug and memory leaks

### DIFF
--- a/lib/tcp.js
+++ b/lib/tcp.js
@@ -7,7 +7,6 @@ var Net = require('net')
 var Stream = require('stream')
 var Ndjson = require('ndjson')
 var Reconnect = require('reconnect-core')
-var _ = require('lodash')
 
 // Declare internals
 var internals = {}
@@ -22,8 +21,14 @@ exports.listen = function (options, transportUtil) {
     var listenAttempts = 0
 
     var listener = Net.createServer(function (connection) {
-      seneca.log.debug('listen', 'connection', listenOptions,
-                       'remote', connection.remoteAddress, connection.remotePort)
+      seneca.log.debug(
+        'listen',
+        'connection',
+        listenOptions,
+        'remote',
+        connection.remoteAddress,
+        connection.remotePort
+      )
 
       var parser = Ndjson.parse()
       var stringifier = Ndjson.stringify()
@@ -54,7 +59,12 @@ exports.listen = function (options, transportUtil) {
       stringifier.pipe(connection)
 
       connection.on('error', function (err) {
-        seneca.log.error('listen', 'pipe-error', listenOptions, err && err.stack)
+        seneca.log.error(
+          'listen',
+          'pipe-error',
+          listenOptions,
+          err && err.stack
+        )
       })
 
       connections.push(connection)
@@ -69,10 +79,22 @@ exports.listen = function (options, transportUtil) {
     listener.on('error', function (err) {
       seneca.log.error('listen', 'net-error', listenOptions, err && err.stack)
 
-      if ('EADDRINUSE' === err.code && listenAttempts < listenOptions.max_listen_attempts) {
+      if (
+        'EADDRINUSE' === err.code &&
+        listenAttempts < listenOptions.max_listen_attempts
+      ) {
         listenAttempts++
-        seneca.log.warn('listen', 'attempt', listenAttempts, err.code, listenOptions)
-        setTimeout(listen, 100 + Math.floor(Math.random() * listenOptions.attempt_delay))
+        seneca.log.warn(
+          'listen',
+          'attempt',
+          listenAttempts,
+          err.code,
+          listenOptions
+        )
+        setTimeout(
+          listen,
+          100 + Math.floor(Math.random() * listenOptions.attempt_delay)
+        )
         return
       }
     })
@@ -84,8 +106,7 @@ exports.listen = function (options, transportUtil) {
     function listen () {
       if (listenOptions.path) {
         listener.listen(listenOptions.path)
-      }
-      else {
+      } else {
         listener.listen(listenOptions.port, listenOptions.host)
       }
     }
@@ -105,6 +126,10 @@ exports.listen = function (options, transportUtil) {
 exports.client = function (options, transportUtil) {
   return function (args, callback) {
     var seneca = this.root.delegate()
+    var conStream
+    var connection
+    var established = false
+    var stringifier
 
     var type = args.type
     if (args.host) {
@@ -112,26 +137,23 @@ exports.client = function (options, transportUtil) {
       args.host = args.host === '0.0.0.0' ? '127.0.0.1' : args.host
     }
     var clientOptions = seneca.util.deepextend(options[args.type], args)
-    clientOptions.host = !args.host && clientOptions.host === '0.0.0.0' ? '127.0.0.1' : clientOptions.host
+    clientOptions.host =
+      !args.host && clientOptions.host === '0.0.0.0'
+        ? '127.0.0.1'
+        : clientOptions.host
 
-    var send = function (spec, topic, send_done) {
-      seneca.log.debug('client', type, 'send-init', spec, topic, clientOptions)
-
-      var connections = []
-      var established = false
+    var connect = function () {
+      seneca.log.debug('client', type, 'send-init', '', '', clientOptions)
 
       var reconnect = internals.reconnect(function (stream) {
-        // unique connections are by the options e.g. host:port
-        // don't need to pipe everything again if it exists
-        // established is for a race condition for `connect` event pushing
-        var existing = _.find(connections, { clientOptions: clientOptions })
-        if (!established || existing && existing.setup) {
-          return
-        }
-
-        var msger = internals.clientMessager(seneca, clientOptions, transportUtil)
+        conStream = stream
+        var msger = internals.clientMessager(
+          seneca,
+          clientOptions,
+          transportUtil
+        )
         var parser = Ndjson.parse()
-        var stringifier = Ndjson.stringify()
+        stringifier = Ndjson.stringify()
 
         stream
           .pipe(parser)
@@ -139,34 +161,43 @@ exports.client = function (options, transportUtil) {
           .pipe(stringifier)
           .pipe(stream)
 
-        existing.setup = true
-
-        send_done(null, function (args, done, meta) {
-          var outmsg = transportUtil.prepare_request(this, args, done, meta)
-          if (!outmsg.replied) stringifier.write(outmsg)
-        })
+        if (!established) reconnect.emit('s_connected', stringifier)
+        established = true
       })
 
       reconnect.on('connect', function (connection) {
-        seneca.log.debug('client', type, 'connect', spec, topic, clientOptions)
-        connection.clientOptions = clientOptions // unique per connection
-        connections.push(connection)
-        established = true
+        seneca.log.debug('client', type, 'connect', '', '', clientOptions)
+        // connection.clientOptions = clientOptions // unique per connection
+        // connections.push(connection)
+        // established = true
       })
+
       reconnect.on('reconnect', function () {
-        seneca.log.debug('client', type, 'reconnect', spec, topic, clientOptions)
+        seneca.log.debug('client', type, 'reconnect', '', '', clientOptions)
       })
       reconnect.on('disconnect', function (err) {
-        seneca.log.debug('client', type, 'disconnect', spec, topic, clientOptions,
-           (err && err.stack) || err)
+        seneca.log.debug(
+          'client',
+          type,
+          'disconnect',
+          '',
+          '',
+          clientOptions,
+          (err && err.stack) || err
+        )
 
-        var conn = _.find(connections, { clientOptions: clientOptions })
-        if (conn) {
-          conn.setup = false
-        }
+        established = false
       })
       reconnect.on('error', function (err) {
-        seneca.log.debug('client', type, 'error', spec, topic, clientOptions, err.stack)
+        seneca.log.debug(
+          'client',
+          type,
+          'error',
+          '',
+          '',
+          clientOptions,
+          err.stack
+        )
       })
 
       reconnect.connect({
@@ -176,8 +207,29 @@ exports.client = function (options, transportUtil) {
 
       transportUtil.close(seneca, function (done) {
         reconnect.disconnect()
-        internals.closeConnections(connections, seneca)
+        internals.closeConnections([conStream], seneca)
         done()
+      })
+
+      return reconnect
+    }
+
+    function getClient (cb) {
+      if (!connection) connection = connect()
+      if (established) {
+        cb(stringifier)
+      } else {
+        connection.once('s_connected', cb)
+      }
+    }
+
+    var send = function (spec, topic, send_done) {
+      send_done(null, function (args, done, meta) {
+        var self = this
+        getClient(function (stringifier) {
+          var outmsg = transportUtil.prepare_request(self, args, done, meta)
+          if (!outmsg.replied) stringifier.write(outmsg)
+        })
       })
     }
 
@@ -204,8 +256,7 @@ internals.closeConnections = function (connections, seneca) {
 internals.destroyConnection = function (connection, seneca) {
   try {
     connection.destroy()
-  }
-  catch (e) {
+  } catch (e) {
     seneca.log.error(e)
   }
 }


### PR DESCRIPTION
# Description

This makes the tcp driver actually usable. The reconnect was wrongly used, probably wrong understanding of the functionality. The behavior before ended up creating a new object everytime when the connection needed restablishment. This resulted not only in duplicate messages, but well probably a memory leak as well.

# Tests

Tests are broken due to your styles, which are non fixable, I do not invest any time into code styles, since every and any project has its own. So I expect a proper code style fixer to be in place. I'm going to implement a new transport anyway, but I wanted to send this changes back to you.

Fixes senecajs/seneca-transport#114
Refers to senecajs/seneca-transport#146

#146 is probably fixed by this too but needs verification.

Signed-off-by: Tobias Gurtzick <magic@wizardtales.com>